### PR TITLE
test: add Task 11 adaptive-selection falsification controls

### DIFF
--- a/experiments/adaptive_selection/controls/task11_v1.json
+++ b/experiments/adaptive_selection/controls/task11_v1.json
@@ -1,0 +1,72 @@
+{
+  "claim_scope": "Deterministic positive, null, leakage, memorization, and ID-renaming controls validate falsification mechanics only; they do not establish hosted-model efficacy, natural-feedback causality, provider authenticity, economic benefit, production readiness, or safety.",
+  "control_version": "task11-deterministic-falsification-v1",
+  "decision_gate": {
+    "continue": "Authorize only a bounded frozen real-model trial when every control passes and the known-signal report shows positive task quality, context precision, and required-context recall effects plus fewer misleading selections than the static baseline.",
+    "simplify_or_stop": "Do not fund a real-model trial when the known signal is missed, the null becomes nonzero, leakage executes, ID-local evidence affects held-out selection, opaque renaming changes reusable-feature transfer, or reruns differ. Passing controls alone does not authorize the larger corpus or adaptive product work."
+  },
+  "primary_comparison": {
+    "candidate_selector_mode": "adaptive_policy",
+    "estimand": "heldout-evaluation-adaptive-minus-primary-baseline-v1",
+    "primary_baseline_selector_mode": "static_policy"
+  },
+  "controls": [
+    {
+      "control_id": "known-transferable-signal-v1",
+      "expected": {
+        "context_precision": "positive",
+        "misleading_selected_count": "negative",
+        "required_context_recall": "positive",
+        "task_quality": "positive"
+      },
+      "mechanism": "Use the frozen oracle feedback and feature learner. A condition-independent fake provider returns a fully correct response exactly when the selected context contains every sealed required item; blinded deterministic assessment maps that response to the frozen rubric.",
+      "phase": "evaluation"
+    },
+    {
+      "control_id": "no-signal-null-v1",
+      "expected": {
+        "all_available_primary_effects": "zero",
+        "adaptive_selection": "identical_to_static"
+      },
+      "mechanism": "Raise the prospective minimum evidence threshold above the two-event adaptation prefix so no reusable utility activates; the adaptive selector must reduce exactly to static mechanics.",
+      "phase": "evaluation"
+    },
+    {
+      "control_id": "false-advantage-leakage-v1",
+      "expected": {
+        "execution": "rejected_before_runner"
+      },
+      "mechanism": "Inject sealed evaluation-label vocabulary into an otherwise selector-visible held-out reusable feature and require the existing schema/feature boundary to reject it.",
+      "phase": "preflight"
+    },
+    {
+      "control_id": "id-local-nontransfer-v1",
+      "expected": {
+        "heldout_selection_uses_id_local_estimates": false,
+        "id_local_outcome_ablation_available": false
+      },
+      "mechanism": "Retain ID-local estimates as descriptive evidence only and require every held-out candidate ID to be disjoint from learned adaptation-local estimate targets.",
+      "phase": "evaluation"
+    },
+    {
+      "control_id": "opaque-id-renaming-v1",
+      "expected": {
+        "primary_metric_projection": "identical",
+        "reusable_feature_estimates": "identical",
+        "selected_ids": "same_under_bijection"
+      },
+      "mechanism": "Apply a deterministic opaque bijection to every context ID and all linked sealed/feedback references, rerun the complete runner/report path, and compare mapped selections plus report-level metrics.",
+      "phase": "evaluation"
+    },
+    {
+      "control_id": "deterministic-rerun-v1",
+      "expected": {
+        "artifact_bytes": "identical",
+        "report_bytes": "identical"
+      },
+      "mechanism": "Repeat each executable control with identical frozen inputs and clocks through the public Task 9 and Task 10 entrypoints.",
+      "phase": "all"
+    }
+  ],
+  "persistence_claim": "SQLite regeneration remains unavailable in Task 11 because no complete persisted projection of OrderedExperimentArtifact with source-feedback/run-local reveal linkage is implemented."
+}

--- a/tests/adaptive_selection/test_report.py
+++ b/tests/adaptive_selection/test_report.py
@@ -974,7 +974,12 @@ def test_task11_id_local_evidence_does_not_transfer_and_opaque_renaming_is_invar
                 original.context_item_id: renamed.context_item_id
                 for original, renamed in zip(original_candidates, renamed_candidates)
             }
-            assert id_bijection
+            assert len(id_bijection) == len(original_candidates)
+            assert len(set(id_bijection.values())) == len(renamed_candidates)
+            assert all(
+                original_id != renamed_id
+                for original_id, renamed_id in id_bijection.items()
+            )
             assert (
                 tuple(
                     id_bijection[context_id]

--- a/tests/adaptive_selection/test_report.py
+++ b/tests/adaptive_selection/test_report.py
@@ -10,7 +10,11 @@ from typing import cast
 import pytest
 
 import experiments.adaptive_selection.report as report_module
-from experiments.adaptive_selection.dataset import load_tiny_fixture
+from experiments.adaptive_selection.dataset import (
+    DatasetBundle,
+    load_tiny_fixture,
+    validate_tiny_fixture,
+)
 from experiments.adaptive_selection.learning import LearningPolicy
 from experiments.adaptive_selection.providers import (
     TOKEN_ACCOUNTING_VERSION,
@@ -52,6 +56,7 @@ from experiments.adaptive_selection.selectors import (
     FullContextSelector,
     SimilarityTopKSelector,
     StaticPolicySelector,
+    reusable_features,
 )
 
 UTC = "2026-07-29T12:00:00Z"
@@ -87,6 +92,9 @@ def _artifact(
     first_arm_classification="reference",
     repetition_count=2,
     bundle_transform=None,
+    learning_policy=None,
+    response_rule=None,
+    step_status_rule=None,
 ):
     bundle = load_tiny_fixture(
         Path(__file__).parent / "fixtures" / "tiny_experiment.json"
@@ -143,14 +151,19 @@ def _artifact(
                 ):
                     continue
                 request = renderer.render(case.inputs, selected)
+                fixture_response = (
+                    response_rule(case, selected)
+                    if response_rule is not None
+                    else response_text
+                )
                 fixtures[request.request_hash] = RawTransportResult(
                     "recorded",
                     "model",
                     "rev",
-                    response_text,
-                    response_text.encode("utf-8") or b"empty-response",
+                    fixture_response,
+                    fixture_response.encode("utf-8") or b"empty-response",
                     10,
-                    int(bool(response_text)),
+                    int(bool(fixture_response)),
                     "req",
                 )
     arms = (
@@ -180,6 +193,11 @@ def _artifact(
 
     class Assessor:
         def assess(self, packet):
+            assessed_step_status = (
+                step_status_rule(packet)
+                if step_status_rule is not None
+                else step_status
+            )
             return BlindedAssessment(
                 packet.output_id,
                 packet.scoring_spec.rubric_id,
@@ -188,10 +206,20 @@ def _artifact(
                 tuple(
                     StepAssessment(
                         step.step_id,
-                        step_status,
+                        assessed_step_status,
                         (
-                            (EvidenceSpan(0, 6, "answer"),)
-                            if step_status == "met"
+                            (
+                                (
+                                    EvidenceSpan(
+                                        0,
+                                        len(packet.response_text),
+                                        packet.response_text,
+                                    ),
+                                )
+                                if step_status_rule is not None
+                                else (EvidenceSpan(0, 6, "answer"),)
+                            )
+                            if assessed_step_status == "met"
                             else ()
                         ),
                     )
@@ -226,7 +254,7 @@ def _artifact(
         "abc123",
         renderer.template_spec,
         renderer.template_hash,
-        LearningPolicy(),
+        learning_policy or LearningPolicy(),
         99,
         source.family_order,
         arms,
@@ -656,3 +684,322 @@ def test_adverse_effects_and_each_derived_report_surface_survive_or_reject_forge
     _rehash_report(forged_flag)
     with pytest.raises(ValueError, match="canonical derived report"):
         ExperimentReport.from_dict(forged_flag)
+
+
+TASK11_CONTROL_SPEC = (
+    Path(__file__).parents[2]
+    / "experiments"
+    / "adaptive_selection"
+    / "controls"
+    / "task11_v1.json"
+)
+TASK11_CONTROL_SPEC_SHA256 = (
+    "a8a95482b406276a5ec594322c2a52a3029022d50ab3b73cf3e6c4c7ebdb74d4"
+)
+
+
+def _task11_response(case, selected):
+    selected_ids = {item.context_item_id for item in selected}
+    required_ids = set(case.sealed_evaluation.required_context_item_ids)
+    return "complete" if required_ids.issubset(selected_ids) else "incomplete"
+
+
+def _task11_step_status(packet):
+    return "met" if packet.response_text == "complete" else "not_met"
+
+
+def _primary_means(report):
+    return {
+        item.metric: Fraction(item.mean.numerator, item.mean.denominator)
+        for item in report.primary_summaries
+        if item.family_id is None and item.mean.available
+    }
+
+
+def _rename_tiny_ids(_bundle):
+    payload = json.loads(
+        (Path(__file__).parent / "fixtures" / "tiny_experiment.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for case_index, case in enumerate(payload["cases"]):
+        mapping = {
+            item["context_item_id"]: "opaque-{}-{}".format(case_index, item_index)
+            for item_index, item in enumerate(case["inputs"]["candidate_context"])
+        }
+        for item in case["inputs"]["candidate_context"]:
+            item["context_item_id"] = mapping[item["context_item_id"]]
+        sealed = case["sealed_evaluation"]
+        for key in (
+            "required_context_item_ids",
+            "useful_context_item_ids",
+            "misleading_context_item_ids",
+            "irrelevant_context_item_ids",
+        ):
+            sealed[key] = [mapping[item] for item in sealed[key]]
+        for event in payload["adaptation_feedback"]:
+            if event["task_case_id"] != case["task_case_id"]:
+                continue
+            event["affected_context_item_ids"] = [
+                mapping[item] for item in event["affected_context_item_ids"]
+            ]
+            for key in ("useful_context_item_ids", "harmful_context_item_ids"):
+                event["structured_value"][key] = [
+                    mapping[item] for item in event["structured_value"][key]
+                ]
+    renamed = DatasetBundle.from_dict(payload)
+    validate_tiny_fixture(renamed)
+    return renamed
+
+
+def _leaky_tiny_bundle(bundle):
+    payload = bundle.to_dict()
+    heldout = next(case for case in payload["cases"] if case["split"] == "held_out")
+    heldout["inputs"]["candidate_context"][0]["metadata"]["learning_attributes"].append(
+        "tag:required"
+    )
+    return DatasetBundle.from_dict(payload)
+
+
+def test_task11_control_spec_is_frozen_before_control_execution():
+    raw = TASK11_CONTROL_SPEC.read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == TASK11_CONTROL_SPEC_SHA256
+    control = json.loads(raw)
+    assert control["primary_comparison"] == {
+        "candidate_selector_mode": "adaptive_policy",
+        "estimand": "heldout-evaluation-adaptive-minus-primary-baseline-v1",
+        "primary_baseline_selector_mode": "static_policy",
+    }
+    assert [item["control_id"] for item in control["controls"]] == [
+        "known-transferable-signal-v1",
+        "no-signal-null-v1",
+        "false-advantage-leakage-v1",
+        "id-local-nontransfer-v1",
+        "opaque-id-renaming-v1",
+        "deterministic-rerun-v1",
+    ]
+    assert "SQLite regeneration remains unavailable" in control["persistence_claim"]
+
+
+def test_task11_known_signal_is_detected_through_runner_and_primary_report():
+    artifact = _artifact(
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    report = build_experiment_report(artifact, _spec())
+    means = _primary_means(report)
+    assert means["task_quality"] > 0
+    assert means["context_precision"] > 0
+    assert means["required_context_recall"] > 0
+    assert means["misleading_selected_count"] < 0
+
+    rerun = _artifact(
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    rerun_report = build_experiment_report(rerun, _spec())
+    assert artifact.canonical_bytes() == rerun.canonical_bytes()
+    assert report.canonical_bytes() == rerun_report.canonical_bytes()
+
+
+def test_task11_no_signal_preserves_exact_null_and_static_equivalence():
+    artifact = _artifact(
+        learning_policy=LearningPolicy(minimum_evidence_count=3),
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    report = build_experiment_report(artifact, _spec())
+    means = _primary_means(report)
+    assert {
+        "task_quality",
+        "context_precision",
+        "required_context_recall",
+        "misleading_selected_count",
+    }.issubset(means)
+    assert all(value == 0 for value in means.values())
+    rerun = _artifact(
+        learning_policy=LearningPolicy(minimum_evidence_count=3),
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    assert artifact.canonical_bytes() == rerun.canonical_bytes()
+    assert (
+        report.canonical_bytes()
+        == build_experiment_report(rerun, _spec()).canonical_bytes()
+    )
+    for repetition in range(2):
+        static = next(
+            run
+            for run in artifact.arm_runs
+            if run.arm_id == "static" and run.repetition_index == repetition
+        )
+        adaptive = next(
+            run
+            for run in artifact.arm_runs
+            if run.arm_id == "adaptive" and run.repetition_index == repetition
+        )
+        assert [
+            item.selection_decision.selected_context_item_ids
+            for item in adaptive.task_records
+        ] == [
+            item.selection_decision.selected_context_item_ids
+            for item in static.task_records
+        ]
+
+
+def test_task11_false_advantage_feature_leak_is_rejected_before_runner():
+    fixture = Path(__file__).parent / "fixtures" / "tiny_experiment.json"
+    leaky_bundle = _leaky_tiny_bundle(load_tiny_fixture(fixture))
+    leaky_case = next(case for case in leaky_bundle.cases if case.split == "held_out")
+    validation_errors = []
+    feature_errors = []
+    for _ in range(2):
+        with pytest.raises(
+            ValueError, match="candidate attribute is absent from ontology"
+        ) as validation_error:
+            validate_tiny_fixture(leaky_bundle)
+        validation_errors.append(str(validation_error.value))
+        with pytest.raises(
+            ValueError, match="reserved evaluation vocabulary"
+        ) as feature_error:
+            reusable_features(
+                leaky_case.inputs.candidate_context[0],
+                tuple(
+                    item.context_item_id for item in leaky_case.inputs.candidate_context
+                ),
+            )
+        feature_errors.append(str(feature_error.value))
+    assert validation_errors[0] == validation_errors[1]
+    assert feature_errors[0] == feature_errors[1]
+
+    # Deliberately bypassing the tiny-fixture preflight still cannot turn the label into
+    # adaptive utility: the full runner records candidate-local processing rejection.
+    artifact = _artifact(bundle_transform=_leaky_tiny_bundle)
+    rerun = _artifact(bundle_transform=_leaky_tiny_bundle)
+    report = build_experiment_report(artifact, _spec())
+    assert artifact.canonical_bytes() == rerun.canonical_bytes()
+    assert (
+        report.canonical_bytes()
+        == build_experiment_report(rerun, _spec()).canonical_bytes()
+    )
+    leaky_id = leaky_case.inputs.candidate_context[0].context_item_id
+    heldout_adaptive_tasks = tuple(
+        task
+        for run in artifact.arm_runs
+        if run.arm_id == "adaptive"
+        for task in run.task_records
+        if task.phase == "evaluation" and task.task_case_id == leaky_case.task_case_id
+    )
+    assert len(heldout_adaptive_tasks) == 2
+    for task in heldout_adaptive_tasks:
+        decision = next(
+            item
+            for item in task.selection_result.decisions
+            if item.context_item_id == leaky_id
+        )
+        assert decision.included is False
+        assert decision.reason == "processing_error"
+
+
+def test_task11_id_local_evidence_does_not_transfer_and_opaque_renaming_is_invariant():
+    original_artifact = _artifact(
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    original_report = build_experiment_report(original_artifact, _spec())
+    renamed_artifact = _artifact(
+        bundle_transform=_rename_tiny_ids,
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    renamed_report = build_experiment_report(renamed_artifact, _spec())
+    renamed_rerun = _artifact(
+        bundle_transform=_rename_tiny_ids,
+        response_rule=_task11_response,
+        step_status_rule=_task11_step_status,
+    )
+    assert renamed_artifact.canonical_bytes() == renamed_rerun.canonical_bytes()
+    assert (
+        renamed_report.canonical_bytes()
+        == build_experiment_report(renamed_rerun, _spec()).canonical_bytes()
+    )
+
+    assert original_report.id_local_outcome_ablation_available is False
+    assert renamed_report.id_local_outcome_ablation_available is False
+    original_means = _primary_means(original_report)
+    renamed_means = _primary_means(renamed_report)
+    assert {
+        "task_quality",
+        "context_precision",
+        "required_context_recall",
+        "misleading_selected_count",
+    }.issubset(original_means)
+    assert original_means == renamed_means
+
+    original_feature_estimates = [
+        estimate.to_dict()
+        for evidence in original_report.learning_evidence
+        for estimate in evidence.estimates
+        if estimate.estimate_kind == "feature"
+    ]
+    renamed_feature_estimates = [
+        estimate.to_dict()
+        for evidence in renamed_report.learning_evidence
+        for estimate in evidence.estimates
+        if estimate.estimate_kind == "feature"
+    ]
+    assert original_feature_estimates
+    assert original_feature_estimates == renamed_feature_estimates
+
+    for original_run in original_artifact.arm_runs:
+        renamed_run = next(
+            run
+            for run in renamed_artifact.arm_runs
+            if run.arm_id == original_run.arm_id
+            and run.repetition_index == original_run.repetition_index
+        )
+        assert len(original_run.task_records) == len(renamed_run.task_records)
+        for original_task, renamed_task in zip(
+            original_run.task_records, renamed_run.task_records
+        ):
+            assert original_task.task_case_id == renamed_task.task_case_id
+            original_candidates = (
+                original_task.case_material.task_case.inputs.candidate_context
+            )
+            renamed_candidates = (
+                renamed_task.case_material.task_case.inputs.candidate_context
+            )
+            assert len(original_candidates) == len(renamed_candidates)
+            id_bijection = {
+                original.context_item_id: renamed.context_item_id
+                for original, renamed in zip(original_candidates, renamed_candidates)
+            }
+            assert id_bijection
+            assert (
+                tuple(
+                    id_bijection[context_id]
+                    for context_id in original_task.selection_decision.selected_context_item_ids
+                )
+                == renamed_task.selection_decision.selected_context_item_ids
+            )
+
+    for artifact in (original_artifact, renamed_artifact):
+        for run in artifact.arm_runs:
+            if run.arm_id != "adaptive":
+                continue
+            for task in run.task_records:
+                if task.phase != "evaluation":
+                    continue
+                heldout_ids = {
+                    item.context_item_id
+                    for item in task.case_material.task_case.inputs.candidate_context
+                }
+                id_local_targets = {
+                    item["context_item_id"]
+                    for item in task.learning_state_before.snapshot_payload[
+                        "id_local_estimates"
+                    ]
+                }
+                assert heldout_ids
+                assert id_local_targets
+                assert heldout_ids.isdisjoint(id_local_targets)


### PR DESCRIPTION
## Summary

- freeze a versioned Task 11 deterministic falsification-control manifest before the executable controls
- exercise known-signal, exact-null, leakage, ID-local non-transfer, opaque-ID-renaming, and deterministic-rerun controls through the existing ordered runner and paired reporting path
- keep claims bounded to falsification mechanics and explicitly decline SQLite regeneration, hosted-model efficacy, natural-feedback causality, economic benefit, production readiness, and safety

## Control results

The deterministic positive control produced the prospectively required overall adaptive-minus-static effects:

- task quality: `+1/2`
- context precision: `+1/8`
- required-context recall: `+1/4`
- misleading selected count: `-1`

The no-signal control produced exact zero available primary effects and identical adaptive/static selections. Leakage failed mandatory tiny-fixture preflight and reusable-feature validation; even with deliberate preflight bypass, the runner recorded candidate-local `processing_error` and did not select the leaked candidate. Opaque ID renaming preserved reusable-feature estimates, report projections, and selected IDs under the declared bijection. ID-local estimates remained descriptive and disjoint from held-out IDs.

These controls validate deterministic falsification mechanics only. They authorize at most a bounded, frozen real-model trial—not the larger corpus or product work.

## Verification

- `pytest tests/adaptive_selection/test_report.py -q` — 16 passed
- `pytest -q` — passed, with the expected optional PostgreSQL integration skip
- Python 3.9 grammar parse — passed
- `black --check --target-version py39 --fast tests/adaptive_selection/test_report.py` — passed
- `isort --check-only tests/adaptive_selection/test_report.py` — passed
- `python -m build` — wheel and sdist built successfully
- `git diff --check` — passed
- adversarial specification/methods review — PASS, no findings after remediation
- closing code-quality review — PASS, no findings after remediation

## Known limitation

SQLite regeneration remains unavailable because there is no complete persisted projection of `OrderedExperimentArtifact` with honest source-feedback/run-local reveal linkage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to an experiment control manifest and deterministic tests; no production runner, selector, or reporting logic is modified in this diff.
> 
> **Overview**
> Adds a **frozen** `task11_v1.json` manifest (SHA256-pinned in tests) that defines six deterministic falsification controls, decision gates, and bounded claim scope for adaptive vs static selection—without asserting hosted-model efficacy or SQLite persistence.
> 
> Extends the report test harness so `_artifact` can drive **oracle responses** from sealed required-context coverage, custom step scoring, alternate `LearningPolicy`, and bundle mutations. New tests run the existing ordered runner and `build_experiment_report` path against: **known transferable signal** (positive primary effects + byte-identical reruns), **no-signal null** (zero effects and adaptive/static selection parity via raised `minimum_evidence_count`), **evaluation-label leakage** (preflight/`reusable_features` rejection and runner `processing_error` on leaked candidates), and **ID-local non-transfer plus opaque ID renaming** (disjoint held-out vs id-local targets, invariant metrics/estimates/selections under bijection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b298428a02128f04fd1da147ff806e28c652cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->